### PR TITLE
logger mer detaljert om infotrygd-data for å prøve å se sammenheng

### DIFF
--- a/src/main/kotlin/no/nav/helse/domene/ytelse/YtelseService.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/YtelseService.kt
@@ -1,5 +1,6 @@
 package no.nav.helse.domene.ytelse
 
+import arrow.core.Either
 import arrow.core.flatMap
 import no.nav.helse.Feilårsak
 import no.nav.helse.domene.AktørId
@@ -95,6 +96,10 @@ class YtelseService(private val aktørregisterService: AktørregisterService,
 
                         sakerMedGrunnlag
                     }
+                }
+            }.also { either ->
+                if (either is Either.Right) {
+                    probe.inspiserInfotrygdSakerOgGrunnlag(either.b)
                 }
             }
 

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/domain/Behandlingstema.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/domain/Behandlingstema.kt
@@ -24,7 +24,7 @@ sealed class Behandlingstema(val kode: String, val tema: Tema) {
 
     object Overgangsstønad: Behandlingstema("OG", Tema.EnsligForsørger)
 
-    class Ukjent(kode: String): Behandlingstema(kode, Tema.Ukjent)
+    class Ukjent(kode: String): Behandlingstema(kode, Tema.Ukjent("??"))
 
     fun name() = when (this) {
         is Foreldrepenger -> "Foreldrepenger"

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/domain/Tema.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/domain/Tema.kt
@@ -7,7 +7,7 @@ sealed class Tema {
     object Engangsstønad: Tema()
     object PårørendeSykdom: Tema()
     object EnsligForsørger: Tema()
-    object Ukjent: Tema()
+    data class Ukjent(val tema: String): Tema()
 
     fun name() = when (this) {
         is Sykepenger -> "Sykepenger"
@@ -29,7 +29,7 @@ sealed class Tema {
                     "FA" -> Tema.Foreldrepenger
                     "BS" -> Tema.PårørendeSykdom
                     "EF" -> Tema.EnsligForsørger
-                    else -> Tema.Ukjent
+                    else -> Tema.Ukjent(tema)
                 }
     }
 }

--- a/src/test/kotlin/no/nav/helse/domene/ytelse/domain/BehandlingstemaTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/ytelse/domain/BehandlingstemaTest.kt
@@ -73,4 +73,33 @@ class BehandlingstemaTest {
             assertEquals(kclass, fraKode(kodeverdi)::class)
         }
     }
+
+    @Test
+    fun `skal ha riktig string-representasjon`() {
+        val expected = mapOf(
+                "FP" to "Foreldrepenger(kode='FP', tema=Foreldrepenger)",
+                "FØ" to "ForeldrepengerMedFødsel(kode='FØ', tema=Foreldrepenger)",
+                "FU" to "ForeldrepengerMedFødselUtland(kode='FU', tema=Foreldrepenger)",
+                "AP" to "ForeldrepengerMedAdopsjon(kode='AP', tema=Foreldrepenger)",
+                "SV" to "Svangerskapspenger(kode='SV', tema=Foreldrepenger)",
+                "AE" to "EngangstønadMedAdopsjon(kode='AE', tema=Foreldrepenger)",
+                "FE" to "EngangstønadMedFødsel(kode='FE', tema=Foreldrepenger)",
+                "OM" to "Omsorgspenger(kode='OM', tema=PårørendeSykdom)",
+                "OP" to "Opplæringspenger(kode='OP', tema=PårørendeSykdom)",
+                "PB" to "PleiepengerSyktBarnFør2017_10_01(kode='PB', tema=PårørendeSykdom)",
+                "PI" to "PleiepengerFør2017_10_01(kode='PI', tema=PårørendeSykdom)",
+                "PP" to "PleiepengerPårørende(kode='PP', tema=PårørendeSykdom)",
+                "PN" to "Pleiepenger(kode='PN', tema=PårørendeSykdom)",
+                "SP" to "Sykepenger(kode='SP', tema=Sykepenger)",
+                "RS" to "SykepengerForsikringRisikoSykefravær(kode='RS', tema=Sykepenger)",
+                "RT" to "SykepengerReisetilskudd(kode='RT', tema=Sykepenger)",
+                "SU" to "SykepengerUtenlandsopphold(kode='SU', tema=Sykepenger)",
+                "OG" to "Overgangsstønad(kode='OG', tema=EnsligForsørger)",
+                "ZZ" to "Ukjent(kode='ZZ', tema=Ukjent(tema=??))"
+        )
+
+        expected.forEach { kodeverdi, string ->
+            assertEquals(string, fraKode(kodeverdi).toString())
+        }
+    }
 }

--- a/src/test/kotlin/no/nav/helse/domene/ytelse/domain/TemaTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/ytelse/domain/TemaTest.kt
@@ -3,6 +3,7 @@ package no.nav.helse.domene.ytelse.domain
 import no.nav.helse.domene.ytelse.domain.Tema.*
 import no.nav.helse.domene.ytelse.domain.Tema.Companion.fraKode
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class TemaTest {
@@ -13,5 +14,15 @@ class TemaTest {
         assertEquals(Foreldrepenger, fraKode("FA"))
         assertEquals(PårørendeSykdom, fraKode("BS"))
         assertEquals(EnsligForsørger, fraKode("EF"))
+        assertTrue(fraKode("ZZ") is Ukjent)
+    }
+
+    @Test
+    fun `skal ha riktig string-representasjon`() {
+        assertEquals("Sykepenger", fraKode("SP").toString())
+        assertEquals("Foreldrepenger", fraKode("FA").toString())
+        assertEquals("PårørendeSykdom", fraKode("BS").toString())
+        assertEquals("EnsligForsørger", fraKode("EF").toString())
+        assertEquals("Ukjent(tema=ZZ)", fraKode("ZZ").toString())
     }
 }


### PR DESCRIPTION
mål:
* logge/telle tilfeller hvor behandlingstema og tema har ukjent verdi
* logge/telle tilfeller hvor utbetalingsgrad er null, for å se om det står i sammenheng med grunnlagstypen (sykepenger, foreldrepenger, osv)
* logge/telle tilfeller hvor vi finner flere grunnlag for en sak. P.t. vet vi ikke om en sak har ett grunnlag alltid, eller om det kan ha flere
* logge/telle tilfeller hvor periodeFom og periodeTom er null, eller om periodeFom > periodeTom, og om det kan ha sammenheng med grunnlagstypen (sykepenger, foreldrepenger, osv)