### PR TITLE
Det er én-til-én mellom en InfotrygdVedtak og et Beregningsgrunnlag 

### DIFF
--- a/src/main/kotlin/no/nav/helse/domene/ytelse/YtelseDtoMapper.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/YtelseDtoMapper.kt
@@ -25,7 +25,7 @@ object YtelseDtoMapper {
                             behandlingstema = sakOgGrunnlag.sak.behandlingstema.name(),
                             opphørerFom = sakOgGrunnlag.sak.opphørerFom
                     ),
-                    grunnlag = sakOgGrunnlag.grunnlag.map(::toDto)
+                    grunnlag = sakOgGrunnlag.grunnlag?.let(::toDto)
             )
 
     fun toDto(beregningsgrunnlag: Beregningsgrunnlag) =

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/YtelseService.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/YtelseService.kt
@@ -109,7 +109,7 @@ class YtelseService(private val aktørregisterService: AktørregisterService,
                         }
 
                         sakerMedGrunnlag.filter { infotrygdSakOgGrunnlag ->
-                            infotrygdSakOgGrunnlag.grunnlag.isEmpty()
+                            infotrygdSakOgGrunnlag.grunnlag == null
                         }.forEach { sakUtenGrunnlag ->
                             log.info("finner ikke grunnlag for sak med sakId=${sakUtenGrunnlag.sak.sakId}")
                         }
@@ -127,11 +127,11 @@ class YtelseService(private val aktørregisterService: AktørregisterService,
         val grunnlagUtenSak = grunnlagliste.toMutableList()
 
         return saker.map { sak ->
-            val grunnlag = grunnlagUtenSak.filter { grunnlag ->
+            val grunnlag = grunnlagUtenSak.firstOrNull { grunnlag ->
                 grunnlag.hørerSammenMed(sak)
+            }?.also {
+                grunnlagUtenSak.remove(it)
             }
-
-            grunnlagUtenSak.removeAll(grunnlag)
 
             InfotrygdSakOgGrunnlag(sak, grunnlag)
         }.let { sakerMedGrunnlag ->

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/domain/InfotrygdSakOgGrunnlag.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/domain/InfotrygdSakOgGrunnlag.kt
@@ -2,5 +2,5 @@ package no.nav.helse.domene.ytelse.domain
 
 data class InfotrygdSakOgGrunnlag(
         val sak: InfotrygdSak,
-        val grunnlag: List<Beregningsgrunnlag>
+        val grunnlag: Beregningsgrunnlag?
 )

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/dto/InfotrygdSakOgGrunnlag.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/dto/InfotrygdSakOgGrunnlag.kt
@@ -2,5 +2,5 @@ package no.nav.helse.domene.ytelse.dto
 
 data class InfotrygdSakOgGrunnlagDto(
         val sak: InfotrygdSakDto,
-        val grunnlag: List<BeregningsgrunnlagDto>
+        val grunnlag: BeregningsgrunnlagDto?
 )

--- a/src/main/kotlin/no/nav/helse/probe/DatakvalitetProbe.kt
+++ b/src/main/kotlin/no/nav/helse/probe/DatakvalitetProbe.kt
@@ -102,7 +102,6 @@ class DatakvalitetProbe(sensuClient: SensuClient, private val organisasjonServic
         OrganisasjonErJuridiskEnhet,
         OrganisasjonErVirksomhet,
         OrganisasjonErOrganisasjonsledd,
-        FlereGrunnlag,
         UkjentTema,
         UtbetalingsgradMangler,
         HullIAnvistPeriode
@@ -228,12 +227,7 @@ class DatakvalitetProbe(sensuClient: SensuClient, private val organisasjonServic
     fun inspiserInfotrygdSakerOgGrunnlag(saker: List<InfotrygdSakOgGrunnlag>) {
         saker.forEach { sakMedGrunnlag ->
             inspiserSak(sakMedGrunnlag.sak)
-
-            if (sakMedGrunnlag.grunnlag.size > 1) {
-                sendDatakvalitetEvent(sakMedGrunnlag, "grunnlag", Observasjonstype.FlereGrunnlag, "${sakMedGrunnlag.sak} har ${sakMedGrunnlag.grunnlag.size} grunnlag")
-            }
-
-            sakMedGrunnlag.grunnlag.forEach(::inspiserGrunnlag)
+            sakMedGrunnlag.grunnlag?.let(::inspiserGrunnlag)
         }
     }
 

--- a/src/test/kotlin/no/nav/helse/domene/ytelse/YtelseComponentTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/ytelse/YtelseComponentTest.kt
@@ -259,16 +259,14 @@ private val expectedJson = """
           "behandlingstema": "Sykepenger",
           "iverksatt": "2019-05-28"
         },
-        "grunnlag": [
-          {
-            "type": "Sykepenger",
-            "periodeTom": "2019-05-31",
-            "vedtak": [],
-            "behandlingstema": "Sykepenger",
-            "identdato": "2019-05-28",
-            "periodeFom": "2019-05-01"
-          }
-        ]
+        "grunnlag": {
+          "type": "Sykepenger",
+          "periodeTom": "2019-05-31",
+          "vedtak": [],
+          "behandlingstema": "Sykepenger",
+          "identdato": "2019-05-28",
+          "periodeFom": "2019-05-01"
+        }
       },
       {
         "sak": {
@@ -277,16 +275,14 @@ private val expectedJson = """
           "behandlingstema": "ForeldrepengerMedFødsel",
           "iverksatt": "2019-05-14"
         },
-        "grunnlag": [
-          {
-            "type": "Foreldrepenger",
-            "periodeTom": "2019-05-31",
-            "vedtak": [],
-            "behandlingstema": "ForeldrepengerMedFødsel",
-            "identdato": "2019-05-14",
-            "periodeFom": "2019-05-01"
-          }
-        ]
+        "grunnlag": {
+          "type": "Foreldrepenger",
+          "periodeTom": "2019-05-31",
+          "vedtak": [],
+          "behandlingstema": "ForeldrepengerMedFødsel",
+          "identdato": "2019-05-14",
+          "periodeFom": "2019-05-01"
+        }
       },
       {
         "sak": {
@@ -295,16 +291,14 @@ private val expectedJson = """
           "behandlingstema": "EngangstønadMedFødsel",
           "iverksatt": "2019-05-07"
         },
-        "grunnlag": [
-          {
-            "type": "Engangstønad",
-            "periodeTom": "2019-05-31",
-            "vedtak": [],
-            "behandlingstema": "EngangstønadMedFødsel",
-            "identdato": "2019-05-07",
-            "periodeFom": "2019-05-01"
-          }
-        ]
+        "grunnlag": {
+          "type": "Engangstønad",
+          "periodeTom": "2019-05-31",
+          "vedtak": [],
+          "behandlingstema": "EngangstønadMedFødsel",
+          "identdato": "2019-05-07",
+          "periodeFom": "2019-05-01"
+        }
       },
       {
         "sak": {
@@ -313,16 +307,14 @@ private val expectedJson = """
           "behandlingstema": "Pleiepenger",
           "iverksatt": "2019-05-01"
         },
-        "grunnlag": [
-          {
-            "type": "PårørendeSykdom",
-            "periodeTom": "2019-05-31",
-            "vedtak": [],
-            "behandlingstema": "Pleiepenger",
-            "identdato": "2019-05-01",
-            "periodeFom": "2019-05-01"
-          }
-        ]
+        "grunnlag": {
+          "type": "PårørendeSykdom",
+          "periodeTom": "2019-05-31",
+          "vedtak": [],
+          "behandlingstema": "Pleiepenger",
+          "identdato": "2019-05-01",
+          "periodeFom": "2019-05-01"
+        }
       }
     ]
 }

--- a/src/test/kotlin/no/nav/helse/domene/ytelse/YtelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/ytelse/YtelseServiceTest.kt
@@ -90,14 +90,12 @@ class YtelseServiceTest {
                                 behandlingstema = no.nav.helse.domene.ytelse.domain.Behandlingstema.Sykepenger,
                                 opphørerFom = null
                         ),
-                        grunnlag = listOf(
-                                Beregningsgrunnlag.Sykepenger(
-                                        identdato = identdatoSykepenger,
-                                        periodeFom = fom,
-                                        periodeTom = tom,
-                                        behandlingstema = no.nav.helse.domene.ytelse.domain.Behandlingstema.Sykepenger,
-                                        vedtak = emptyList()
-                                )
+                        grunnlag = Beregningsgrunnlag.Sykepenger(
+                                identdato = identdatoSykepenger,
+                                periodeFom = fom,
+                                periodeTom = tom,
+                                behandlingstema = no.nav.helse.domene.ytelse.domain.Behandlingstema.Sykepenger,
+                                vedtak = emptyList()
                         )
                 ),
                 InfotrygdSakOgGrunnlag(
@@ -108,14 +106,12 @@ class YtelseServiceTest {
                                 behandlingstema = no.nav.helse.domene.ytelse.domain.Behandlingstema.ForeldrepengerMedFødsel,
                                 opphørerFom = null
                         ),
-                        grunnlag = listOf(
-                                Beregningsgrunnlag.Foreldrepenger(
-                                        identdato = identdatoForeldrepenger,
-                                        periodeFom = fom,
-                                        periodeTom = tom,
-                                        behandlingstema = no.nav.helse.domene.ytelse.domain.Behandlingstema.ForeldrepengerMedFødsel,
-                                        vedtak = emptyList()
-                                )
+                        grunnlag = Beregningsgrunnlag.Foreldrepenger(
+                                identdato = identdatoForeldrepenger,
+                                periodeFom = fom,
+                                periodeTom = tom,
+                                behandlingstema = no.nav.helse.domene.ytelse.domain.Behandlingstema.ForeldrepengerMedFødsel,
+                                vedtak = emptyList()
                         )
                 ),
                 InfotrygdSakOgGrunnlag(
@@ -126,14 +122,12 @@ class YtelseServiceTest {
                                 behandlingstema = no.nav.helse.domene.ytelse.domain.Behandlingstema.EngangstønadMedFødsel,
                                 opphørerFom = null
                         ),
-                        grunnlag = listOf(
-                                Beregningsgrunnlag.Engangstønad(
-                                        identdato = identdatoEngangstønad,
-                                        periodeFom = fom,
-                                        periodeTom = tom,
-                                        behandlingstema = no.nav.helse.domene.ytelse.domain.Behandlingstema.EngangstønadMedFødsel,
-                                        vedtak = emptyList()
-                                )
+                        grunnlag = Beregningsgrunnlag.Engangstønad(
+                                identdato = identdatoEngangstønad,
+                                periodeFom = fom,
+                                periodeTom = tom,
+                                behandlingstema = no.nav.helse.domene.ytelse.domain.Behandlingstema.EngangstønadMedFødsel,
+                                vedtak = emptyList()
                         )
                 ),
                 InfotrygdSakOgGrunnlag(
@@ -144,14 +138,12 @@ class YtelseServiceTest {
                                 behandlingstema = no.nav.helse.domene.ytelse.domain.Behandlingstema.Pleiepenger,
                                 opphørerFom = null
                         ),
-                        grunnlag = listOf(
-                                Beregningsgrunnlag.PårørendeSykdom(
-                                        identdato = identdatoPleiepenger,
-                                        periodeFom = fom,
-                                        periodeTom = tom,
-                                        behandlingstema = no.nav.helse.domene.ytelse.domain.Behandlingstema.Pleiepenger,
-                                        vedtak = emptyList()
-                                )
+                        grunnlag = Beregningsgrunnlag.PårørendeSykdom(
+                                identdato = identdatoPleiepenger,
+                                periodeFom = fom,
+                                periodeTom = tom,
+                                behandlingstema = no.nav.helse.domene.ytelse.domain.Behandlingstema.Pleiepenger,
+                                vedtak = emptyList()
                         )
                 )
         )


### PR DESCRIPTION
Etter avklaring med Team Infotrygd så har vi blitt fortalt at et grunnlag svarer til én InfotrygdVedtak og vice versa. Vi slipper derfor å ha en `List<Beregningsgrunnlag>` på sakene

Ser eksempler hvor vi finner to grunnlag for en sak, men realiteten er at det også er to saker (der begge grunnlag legger seg på én av dem). Dette oppstår når det er to saker med samme identdato/iverksattdato på samme tema. Rotårsaken til dette er uvisst, pt.