### PR TITLE
Egen exception for når basene er utilgjengelige

### DIFF
--- a/src/main/kotlin/no/nav/helse/domene/sykepengehistorikk/DomainErrorMapper.kt
+++ b/src/main/kotlin/no/nav/helse/domene/sykepengehistorikk/DomainErrorMapper.kt
@@ -1,31 +1,24 @@
 package no.nav.helse.domene.sykepengehistorikk
 
 import no.nav.helse.Feilårsak
+import no.nav.helse.oppslag.infotrygdberegningsgrunnlag.BaseneErUtilgjengeligeException
 import no.nav.tjeneste.virksomhet.infotrygdberegningsgrunnlag.v1.binding.FinnGrunnlagListePersonIkkeFunnet
 import no.nav.tjeneste.virksomhet.infotrygdberegningsgrunnlag.v1.binding.FinnGrunnlagListeSikkerhetsbegrensning
 import no.nav.tjeneste.virksomhet.infotrygdberegningsgrunnlag.v1.binding.FinnGrunnlagListeUgyldigInput
 import org.slf4j.LoggerFactory
-import javax.xml.ws.soap.SOAPFaultException
 
 object DomainErrorMapper {
 
     private val log = LoggerFactory.getLogger(DomainErrorMapper::class.java)
 
     fun mapToError(err: Throwable) =
-            with (err) {
-                log.error("received error during lookup", this)
-
-                when (this) {
-                    is FinnGrunnlagListeSikkerhetsbegrensning -> Feilårsak.FeilFraTjeneste
-                    is FinnGrunnlagListeUgyldigInput -> Feilårsak.FeilFraTjeneste
-                    is FinnGrunnlagListePersonIkkeFunnet -> Feilårsak.IkkeFunnet
-                    is SOAPFaultException -> when (fault.faultString) {
-                        "Basene i Infotrygd er ikke tilgjengelige" -> Feilårsak.TjenesteErUtilgjengelig
-                        else -> Feilårsak.UkjentFeil
-                    }
-                    else -> Feilårsak.UkjentFeil
-                }
+            when (err) {
+                is FinnGrunnlagListeSikkerhetsbegrensning -> Feilårsak.FeilFraTjeneste
+                is FinnGrunnlagListeUgyldigInput -> Feilårsak.FeilFraTjeneste
+                is FinnGrunnlagListePersonIkkeFunnet -> Feilårsak.IkkeFunnet
+                is BaseneErUtilgjengeligeException -> Feilårsak.TjenesteErUtilgjengelig
+                else -> Feilårsak.UkjentFeil
+            }.also {
+                log.info("received error during lookup, mapping to $it", this)
             }
-
-
 }

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/InfotrygdErrorMapper.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/InfotrygdErrorMapper.kt
@@ -1,0 +1,24 @@
+package no.nav.helse.domene.ytelse
+
+import no.nav.helse.Feilårsak
+import no.nav.helse.oppslag.infotrygdberegningsgrunnlag.BaseneErUtilgjengeligeException
+import no.nav.tjeneste.virksomhet.infotrygdsak.v1.binding.FinnSakListePersonIkkeFunnet
+import no.nav.tjeneste.virksomhet.infotrygdsak.v1.binding.FinnSakListeSikkerhetsbegrensning
+import no.nav.tjeneste.virksomhet.infotrygdsak.v1.binding.FinnSakListeUgyldigInput
+import org.slf4j.LoggerFactory
+
+object InfotrygdErrorMapper {
+
+    private val log = LoggerFactory.getLogger(InfotrygdErrorMapper::class.java)
+
+    fun mapToError(err: Throwable) =
+            when (err) {
+                is FinnSakListeSikkerhetsbegrensning -> Feilårsak.FeilFraTjeneste
+                is FinnSakListeUgyldigInput -> Feilårsak.FeilFraTjeneste
+                is FinnSakListePersonIkkeFunnet -> Feilårsak.IkkeFunnet
+                is BaseneErUtilgjengeligeException -> Feilårsak.TjenesteErUtilgjengelig
+                else -> Feilårsak.UkjentFeil
+            }.also {
+                log.info("received error during lookup, mapping to $it", this)
+            }
+}

--- a/src/main/kotlin/no/nav/helse/oppslag/infotrygd/InfotrygdSakClient.kt
+++ b/src/main/kotlin/no/nav/helse/oppslag/infotrygd/InfotrygdSakClient.kt
@@ -1,17 +1,32 @@
 package no.nav.helse.oppslag.infotrygd
 
 import arrow.core.Try
+import arrow.core.failure
 import no.nav.helse.common.toXmlGregorianCalendar
+import no.nav.helse.oppslag.infotrygdberegningsgrunnlag.BaseneErUtilgjengeligeException
 import no.nav.tjeneste.virksomhet.infotrygdsak.v1.binding.InfotrygdSakV1
 import no.nav.tjeneste.virksomhet.infotrygdsak.v1.informasjon.Periode
 import no.nav.tjeneste.virksomhet.infotrygdsak.v1.meldinger.FinnSakListeRequest
 import java.time.LocalDate
+import javax.xml.ws.soap.SOAPFaultException
 
 class InfotrygdSakClient(private val port: InfotrygdSakV1) {
+
+    companion object {
+        private val baseneErUtilgjengelige = "Basene i Infotrygd er ikke tilgjengelige"
+    }
 
     fun finnSakListe(fødselsnummer: String, fom: LocalDate, tom: LocalDate?) =
             Try {
                 port.finnSakListe(finnSakListeRequest(fødselsnummer, fom, tom))
+            }.let {
+                if (it is Try.Failure && it.exception is SOAPFaultException) {
+                    if ((it.exception as SOAPFaultException).message == baseneErUtilgjengelige) {
+                        return@let BaseneErUtilgjengeligeException(it.exception as SOAPFaultException)
+                                .failure()
+                    }
+                }
+                it
             }
 
     private fun finnSakListeRequest(fødselsnummer: String, fom: LocalDate, tom: LocalDate?) =

--- a/src/main/kotlin/no/nav/helse/oppslag/infotrygdberegningsgrunnlag/BaseneErUtilgjengeligeException.kt
+++ b/src/main/kotlin/no/nav/helse/oppslag/infotrygdberegningsgrunnlag/BaseneErUtilgjengeligeException.kt
@@ -1,0 +1,5 @@
+package no.nav.helse.oppslag.infotrygdberegningsgrunnlag
+
+import javax.xml.ws.soap.SOAPFaultException
+
+class BaseneErUtilgjengeligeException(cause: SOAPFaultException): RuntimeException(cause)

--- a/src/main/kotlin/no/nav/helse/oppslag/infotrygdberegningsgrunnlag/InfotrygdBeregningsgrunnlagClient.kt
+++ b/src/main/kotlin/no/nav/helse/oppslag/infotrygdberegningsgrunnlag/InfotrygdBeregningsgrunnlagClient.kt
@@ -1,19 +1,32 @@
 package no.nav.helse.oppslag.infotrygdberegningsgrunnlag
 
 import arrow.core.Try
+import arrow.core.failure
 import no.nav.helse.common.toXmlGregorianCalendar
 import no.nav.helse.domene.Fødselsnummer
 import no.nav.tjeneste.virksomhet.infotrygdberegningsgrunnlag.v1.binding.InfotrygdBeregningsgrunnlagV1
 import no.nav.tjeneste.virksomhet.infotrygdberegningsgrunnlag.v1.meldinger.FinnGrunnlagListeRequest
 import no.nav.tjeneste.virksomhet.infotrygdberegningsgrunnlag.v1.meldinger.FinnGrunnlagListeResponse
 import java.time.LocalDate
+import javax.xml.ws.soap.SOAPFaultException
 
 class InfotrygdBeregningsgrunnlagClient(private val infotrygdBeregningsgrunnlag : InfotrygdBeregningsgrunnlagV1) {
 
+    companion object {
+        private val baseneErUtilgjengelige = "Basene i Infotrygd er ikke tilgjengelige"
+    }
     fun finnGrunnlagListe(fnr: Fødselsnummer, fraOgMed: LocalDate, tilOgMed: LocalDate) =
             Try {
                 infotrygdBeregningsgrunnlag.finnGrunnlagListe(createFinnGrunnlagListeRequest(fnr.value, fraOgMed, tilOgMed)) ?:
                         FinnGrunnlagListeResponse()
+            }.let {
+                if (it is Try.Failure && it.exception is SOAPFaultException) {
+                    if ((it.exception as SOAPFaultException).message == baseneErUtilgjengelige) {
+                        return@let BaseneErUtilgjengeligeException(it.exception as SOAPFaultException)
+                                .failure()
+                    }
+                }
+                it
             }
 
     private fun createFinnGrunnlagListeRequest(fnr: String, fraOgMed: LocalDate, tilOgMed: LocalDate): FinnGrunnlagListeRequest {

--- a/src/test/kotlin/no/nav/helse/domene/sykepengehistorikk/DomainErrorMapperTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/sykepengehistorikk/DomainErrorMapperTest.kt
@@ -2,6 +2,7 @@ package no.nav.helse.domene.sykepengehistorikk
 
 import no.nav.helse.Feilårsak.*
 import no.nav.helse.domene.sykepengehistorikk.DomainErrorMapper.mapToError
+import no.nav.helse.oppslag.infotrygdberegningsgrunnlag.BaseneErUtilgjengeligeException
 import no.nav.tjeneste.virksomhet.infotrygdberegningsgrunnlag.v1.binding.FinnGrunnlagListePersonIkkeFunnet
 import no.nav.tjeneste.virksomhet.infotrygdberegningsgrunnlag.v1.binding.FinnGrunnlagListeSikkerhetsbegrensning
 import no.nav.tjeneste.virksomhet.infotrygdberegningsgrunnlag.v1.binding.FinnGrunnlagListeUgyldigInput
@@ -30,9 +31,9 @@ class DomainErrorMapperTest {
     }
 
     @Test
-    fun `skal mappe feilmelding til TjenesteErUtilgjengelig når Infotrygd er utilgjengelig`() {
+    fun `skal mappe BaseneErUtilgjengeligeException til TjenesteErUtilgjengelig`() {
         val fault = SOAPFactory.newInstance(SOAPConstants.SOAP_1_1_PROTOCOL).createFault("Basene i Infotrygd er ikke tilgjengelige", QName("nameSpaceURI", "ERROR"))
-        assertEquals(TjenesteErUtilgjengelig, mapToError(SOAPFaultException(fault)))
+        assertEquals(TjenesteErUtilgjengelig, mapToError(BaseneErUtilgjengeligeException(SOAPFaultException(fault))))
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/domene/sykepengehistorikk/SykepengehistorikkComponentTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/sykepengehistorikk/SykepengehistorikkComponentTest.kt
@@ -1,0 +1,79 @@
+package no.nav.helse.domene.sykepengehistorikk
+
+import arrow.core.right
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.handleRequest
+import io.ktor.server.testing.withTestApplication
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.helse.JwtStub
+import no.nav.helse.assertJsonEquals
+import no.nav.helse.common.toLocalDate
+import no.nav.helse.domene.AktørId
+import no.nav.helse.domene.Fødselsnummer
+import no.nav.helse.domene.aktør.AktørregisterService
+import no.nav.helse.mockedSparkel
+import no.nav.helse.oppslag.infotrygdberegningsgrunnlag.InfotrygdBeregningsgrunnlagClient
+import no.nav.tjeneste.virksomhet.infotrygdberegningsgrunnlag.v1.binding.InfotrygdBeregningsgrunnlagV1
+import org.json.JSONObject
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import javax.xml.namespace.QName
+import javax.xml.soap.SOAPConstants
+import javax.xml.soap.SOAPFactory
+import javax.xml.ws.soap.SOAPFaultException
+
+class SykepengehistorikkComponentTest {
+    @Test
+    fun `skal returnere 503 når infotrygd er utilgjengelig`() {
+        val infotrygdBeregningsgrunnlagV1 = mockk<InfotrygdBeregningsgrunnlagV1>()
+        val aktørregisterService = mockk<AktørregisterService>()
+
+        val fnr = Fødselsnummer("11111111111")
+        val aktørId = AktørId("123456789")
+        val fom = LocalDate.of(2019, 5, 1)
+        val tom = LocalDate.of(2019, 5, 31)
+
+        every {
+            aktørregisterService.fødselsnummerForAktør(aktørId)
+        } returns fnr.value.right()
+
+        every {
+            infotrygdBeregningsgrunnlagV1.finnGrunnlagListe(match { request ->
+                request.personident == fnr.value
+                        && request.fom.toLocalDate() == fom
+                        && request.tom.toLocalDate() == tom
+            })
+        } throws SOAPFaultException(SOAPFactory.newInstance(SOAPConstants.SOAP_1_1_PROTOCOL).createFault("Basene i Infotrygd er ikke tilgjengelige", QName("nameSpaceURI", "ERROR")))
+
+        val jwkStub = JwtStub("test issuer")
+        val token = jwkStub.createTokenFor("srvpleiepengesokna")
+
+        withTestApplication({mockedSparkel(
+                jwtIssuer = "test issuer",
+                jwkProvider = jwkStub.stubbedJwkProvider(),
+                sykepengehistorikkService = SykepengehistorikkService(
+                        aktørregisterService = aktørregisterService,
+                        infotrygdBeregningsgrunnlagClient = InfotrygdBeregningsgrunnlagClient(infotrygdBeregningsgrunnlagV1)
+                )
+        )}) {
+            handleRequest(HttpMethod.Get, "/api/sykepengehistorikk/${aktørId.aktor}?fom=$fom&tom=$tom") {
+                addHeader(HttpHeaders.Accept, ContentType.Application.Json.toString())
+                addHeader(HttpHeaders.Authorization, "Bearer $token")
+            }.apply {
+                Assertions.assertEquals(HttpStatusCode.ServiceUnavailable, response.status())
+                assertJsonEquals(JSONObject(expectedJson_service_unavailable), JSONObject(response.content))
+            }
+        }
+    }
+}
+
+private val expectedJson_service_unavailable = """
+{
+  "feilmelding": "Service is unavailable"
+}
+""".trimIndent()

--- a/src/test/kotlin/no/nav/helse/oppslag/infotrygd/InfotrygdSakIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/oppslag/infotrygd/InfotrygdSakIntegrationTest.kt
@@ -1,0 +1,126 @@
+package no.nav.helse.oppslag.infotrygd
+
+import arrow.core.Try
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.MappingBuilder
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.matching.ContainsPattern
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
+import com.github.tomakehurst.wiremock.stubbing.Scenario
+import no.nav.helse.oppslag.*
+import no.nav.helse.oppslag.infotrygdberegningsgrunnlag.BaseneErUtilgjengeligeException
+import no.nav.helse.oppslag.sts.stsClient
+import no.nav.helse.sts.StsRestClient
+import org.junit.jupiter.api.*
+import java.time.LocalDate
+
+class InfotrygdSakIntegrationTest {
+
+    companion object {
+        val server: WireMockServer = WireMockServer(WireMockConfiguration.options().dynamicPort())
+
+        @BeforeAll
+        @JvmStatic
+        fun start() {
+            server.start()
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun stop() {
+            server.stop()
+        }
+    }
+
+    @BeforeEach
+    fun configure() {
+        val client = WireMock.create().port(server.port()).build()
+        WireMock.configureFor(client)
+        client.resetMappings()
+    }
+
+    @Test
+    fun `skal håndtere at basene i infotrygd er utilgjengelige`() {
+        val fnr = "11111111111"
+        val fom = LocalDate.now().minusMonths(1)
+        val tom = LocalDate.now()
+
+        val request = WireMock.post(WireMock.urlPathEqualTo("/infotrygd"))
+                .withSoapAction("http://nav.no/tjeneste/virksomhet/infotrygdSak/v1/infotrygdSak_v1/finnSakListeRequest")
+                .withRequestBody(ContainsPattern("<personident>$fnr</personident>"))
+
+        infotrygdStub(
+                server = server,
+                scenario = "infotrygd_finn_sak_liste",
+                response = WireMock.okXml(basene_i_infotrygd_er_utilgjengelige),
+                request = request
+        ) { infotrygdSakClient ->
+            val actual = infotrygdSakClient.finnSakListe(fnr, fom, tom)
+
+            when (actual) {
+                is Try.Failure -> Assertions.assertTrue(actual.exception is BaseneErUtilgjengeligeException)
+                else -> fail { "Expected Try.Failure to be returned" }
+            }
+        }
+    }
+}
+
+private fun infotrygdStub(server: WireMockServer, scenario: String, response: ResponseDefinitionBuilder, request: MappingBuilder, test: (InfotrygdSakClient) -> Unit) {
+    val stsUsername = "stsUsername"
+    val stsPassword = "stsPassword"
+
+    val tokenSubject = "srvtestapp"
+    val tokenIssuer = "Certificate Authority Inc"
+    val tokenIssuerName = "CN=Certificate Authority Inc, DC=example, DC=com"
+    val tokenDigest = "a random string"
+    val tokenSignature = "yet another random string"
+    val tokenCertificate = "one last random string"
+
+    WireMock.stubFor(stsStub(stsUsername, stsPassword)
+            .willReturn(samlAssertionResponse(tokenSubject, tokenIssuer, tokenIssuerName,
+                    tokenDigest, tokenSignature, tokenCertificate))
+            .inScenario(scenario)
+            .whenScenarioStateIs(Scenario.STARTED)
+            .willSetStateTo("security_token_service_called"))
+
+    WireMock.stubFor(request
+            .withSamlAssertion(tokenSubject, tokenIssuer, tokenIssuerName,
+                    tokenDigest, tokenSignature, tokenCertificate)
+            .withCallId()
+            .willReturn(response)
+            .inScenario(scenario)
+            .whenScenarioStateIs("security_token_service_called")
+            .willSetStateTo("infotrygd_stub_called"))
+
+    val stsClientWs = stsClient(server.baseUrl().plus("/sts"), stsUsername to stsPassword)
+    val stsClientRest = StsRestClient(server.baseUrl().plus("/sts"), stsUsername, stsPassword)
+
+    val wsClients = WsClients(stsClientWs, stsClientRest, true)
+
+    test(wsClients.infotrygdSak(server.baseUrl().plus("/infotrygd")))
+
+    WireMock.listAllStubMappings().mappings.forEach {
+        WireMock.verify(RequestPatternBuilder.like(it.request))
+    }
+}
+
+private val basene_i_infotrygd_er_utilgjengelige = """
+<?xml version='1.0' encoding='UTF-8'?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Header>
+        <Action xmlns="http://www.w3.org/2005/08/addressing">
+            http://nav.no/tjeneste/virksomhet/infotrygdBeregningsgrunnlag/v1/infotrygdBeregningsgrunnlag_v1/finnGrunnlagListe/Fault/SOAPFaultException
+        </Action>
+    </soap:Header>
+    <soap:Body>
+        <soap:Fault>
+            <faultcode>soap:Client</faultcode>
+            <faultstring>Basene i Infotrygd er ikke tilgjengelige</faultstring>
+            <detail></detail>
+        </soap:Fault>
+    </soap:Body>
+</soap:Envelope>
+""".trimIndent()
+

--- a/src/test/kotlin/no/nav/helse/oppslag/infotrygdberegningsgrunnlag/InfotrygdBeregningsgrunnlagIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/oppslag/infotrygdberegningsgrunnlag/InfotrygdBeregningsgrunnlagIntegrationTest.kt
@@ -1,0 +1,131 @@
+package no.nav.helse.oppslag.infotrygdberegningsgrunnlag
+
+import arrow.core.Try
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.MappingBuilder
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.matching.ContainsPattern
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
+import com.github.tomakehurst.wiremock.stubbing.Scenario
+import no.nav.helse.domene.Fødselsnummer
+import no.nav.helse.oppslag.*
+import no.nav.helse.oppslag.sts.stsClient
+import no.nav.helse.sts.StsRestClient
+import no.nav.tjeneste.virksomhet.arbeidsfordeling.v1.informasjon.Organisasjonsenhet
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertTrue
+import java.time.LocalDate
+
+class InfotrygdBeregningsgrunnlagIntegrationTest {
+
+    companion object {
+        val server: WireMockServer = WireMockServer(WireMockConfiguration.options().dynamicPort())
+
+        @BeforeAll
+        @JvmStatic
+        fun start() {
+            server.start()
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun stop() {
+            server.stop()
+        }
+    }
+
+    @BeforeEach
+    fun configure() {
+        val client = WireMock.create().port(server.port()).build()
+        WireMock.configureFor(client)
+        client.resetMappings()
+    }
+
+    @Test
+    fun `skal håndtere at basene i infotrygd er utilgjengelige`() {
+        val fnr = "11111111111"
+        val fom = LocalDate.now().minusMonths(1)
+        val tom = LocalDate.now()
+
+        val request = WireMock.post(WireMock.urlPathEqualTo("/infotrygd"))
+                .withSoapAction("http://nav.no/tjeneste/virksomhet/infotrygdBeregningsgrunnlag/v1/infotrygdBeregningsgrunnlag_v1/finnGrunnlagListeRequest")
+                .withRequestBody(ContainsPattern("<personident>$fnr</personident>"))
+
+        infotrygdStub(
+                server = server,
+                scenario = "infotrygd_finn_grunnlag_liste",
+                response = WireMock.okXml(basene_i_infotrygd_er_utilgjengelige),
+                request = request
+        ) { infotrygdBeregningsgrunnlagClient ->
+            val expected = listOf(Organisasjonsenhet().apply {
+                this.enhetId = enhetId
+                this.enhetNavn = enhetNavn
+            })
+            val actual = infotrygdBeregningsgrunnlagClient.finnGrunnlagListe(Fødselsnummer(fnr), fom, tom)
+
+            when (actual) {
+                is Try.Failure -> assertTrue(actual.exception is BaseneErUtilgjengeligeException)
+                else -> fail { "Expected Try.Failure to be returned" }
+            }
+        }
+    }
+}
+
+private fun infotrygdStub(server: WireMockServer, scenario: String, response: ResponseDefinitionBuilder, request: MappingBuilder, test: (InfotrygdBeregningsgrunnlagClient) -> Unit) {
+    val stsUsername = "stsUsername"
+    val stsPassword = "stsPassword"
+
+    val tokenSubject = "srvtestapp"
+    val tokenIssuer = "Certificate Authority Inc"
+    val tokenIssuerName = "CN=Certificate Authority Inc, DC=example, DC=com"
+    val tokenDigest = "a random string"
+    val tokenSignature = "yet another random string"
+    val tokenCertificate = "one last random string"
+
+    WireMock.stubFor(stsStub(stsUsername, stsPassword)
+            .willReturn(samlAssertionResponse(tokenSubject, tokenIssuer, tokenIssuerName,
+                    tokenDigest, tokenSignature, tokenCertificate))
+            .inScenario(scenario)
+            .whenScenarioStateIs(Scenario.STARTED)
+            .willSetStateTo("security_token_service_called"))
+
+    WireMock.stubFor(request
+            .withSamlAssertion(tokenSubject, tokenIssuer, tokenIssuerName,
+                    tokenDigest, tokenSignature, tokenCertificate)
+            .withCallId()
+            .willReturn(response)
+            .inScenario(scenario)
+            .whenScenarioStateIs("security_token_service_called")
+            .willSetStateTo("infotrygd_stub_called"))
+
+    val stsClientWs = stsClient(server.baseUrl().plus("/sts"), stsUsername to stsPassword)
+    val stsClientRest = StsRestClient(server.baseUrl().plus("/sts"), stsUsername, stsPassword)
+
+    val wsClients = WsClients(stsClientWs, stsClientRest, true)
+
+    test(wsClients.infotrygdBeregningsgrunnlag(server.baseUrl().plus("/infotrygd")))
+
+    WireMock.listAllStubMappings().mappings.forEach {
+        WireMock.verify(RequestPatternBuilder.like(it.request))
+    }
+}
+
+private val basene_i_infotrygd_er_utilgjengelige = """
+<?xml version='1.0' encoding='UTF-8'?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Header>
+        <Action xmlns="http://www.w3.org/2005/08/addressing">
+            http://nav.no/tjeneste/virksomhet/infotrygdBeregningsgrunnlag/v1/infotrygdBeregningsgrunnlag_v1/finnGrunnlagListe/Fault/SOAPFaultException
+        </Action>
+    </soap:Header>
+    <soap:Body>
+        <soap:Fault>
+            <faultcode>soap:Client</faultcode>
+            <faultstring>Basene i Infotrygd er ikke tilgjengelige</faultstring>
+            <detail></detail>
+        </soap:Fault>
+    </soap:Body>
+</soap:Envelope>
+""".trimIndent()

--- a/src/test/kotlin/no/nav/helse/oppslag/infotrygdberegningsgrunnlag/InfotrygdBeregningsgrunnlagIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/oppslag/infotrygdberegningsgrunnlag/InfotrygdBeregningsgrunnlagIntegrationTest.kt
@@ -13,7 +13,6 @@ import no.nav.helse.domene.Fødselsnummer
 import no.nav.helse.oppslag.*
 import no.nav.helse.oppslag.sts.stsClient
 import no.nav.helse.sts.StsRestClient
-import no.nav.tjeneste.virksomhet.arbeidsfordeling.v1.informasjon.Organisasjonsenhet
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertTrue
 import java.time.LocalDate
@@ -59,10 +58,6 @@ class InfotrygdBeregningsgrunnlagIntegrationTest {
                 response = WireMock.okXml(basene_i_infotrygd_er_utilgjengelige),
                 request = request
         ) { infotrygdBeregningsgrunnlagClient ->
-            val expected = listOf(Organisasjonsenhet().apply {
-                this.enhetId = enhetId
-                this.enhetNavn = enhetNavn
-            })
             val actual = infotrygdBeregningsgrunnlagClient.finnGrunnlagListe(Fødselsnummer(fnr), fom, tom)
 
             when (actual) {


### PR DESCRIPTION
Sammenligning mot en feilmelding-tekst bør ikke lekke langt utfor klientkoden — det bør håndteres av klienten selv.
Skrev også en integrasjonstest som (forhåpentligvis) beviser funksjonaliteten