### PR TITLE
Skill mellom infotrygd sak og infotrygd vedtak

### DIFF
--- a/src/main/kotlin/no/nav/helse/domene/ytelse/YtelseDtoMapper.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/YtelseDtoMapper.kt
@@ -1,9 +1,6 @@
 package no.nav.helse.domene.ytelse
 
-import no.nav.helse.domene.ytelse.domain.Beregningsgrunnlag
-import no.nav.helse.domene.ytelse.domain.InfotrygdSakOgGrunnlag
-import no.nav.helse.domene.ytelse.domain.Utbetalingsvedtak
-import no.nav.helse.domene.ytelse.domain.Ytelse
+import no.nav.helse.domene.ytelse.domain.*
 import no.nav.helse.domene.ytelse.dto.*
 
 object YtelseDtoMapper {
@@ -18,14 +15,17 @@ object YtelseDtoMapper {
 
     fun toDto(sakOgGrunnlag: InfotrygdSakOgGrunnlag) =
             InfotrygdSakOgGrunnlagDto(
-                    sak = InfotrygdSakDto(
-                            sakId = sakOgGrunnlag.sak.sakId,
-                            iverksatt = sakOgGrunnlag.sak.iverksatt,
-                            tema = sakOgGrunnlag.sak.tema.name(),
-                            behandlingstema = sakOgGrunnlag.sak.behandlingstema.name(),
-                            opphørerFom = sakOgGrunnlag.sak.opphørerFom
-                    ),
+                    sak = toDto(sakOgGrunnlag.sak),
                     grunnlag = sakOgGrunnlag.grunnlag?.let(::toDto)
+            )
+
+    fun toDto(sak: InfotrygdSak) =
+            InfotrygdSakDto(
+                    sakId = sak.sakId,
+                    iverksatt = sak.iverksatt,
+                    tema = sak.tema.name(),
+                    behandlingstema = sak.behandlingstema.name(),
+                    opphørerFom = if (sak is InfotrygdSak.Vedtak) sak.opphørerFom else null
             )
 
     fun toDto(beregningsgrunnlag: Beregningsgrunnlag) =

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/YtelseDtoMapper.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/YtelseDtoMapper.kt
@@ -21,6 +21,10 @@ object YtelseDtoMapper {
 
     fun toDto(sak: InfotrygdSak) =
             InfotrygdSakDto(
+                    type = when (sak) {
+                        is InfotrygdSak.Vedtak -> "Vedtak"
+                        is InfotrygdSak.Åpen -> "Sak"
+                    },
                     iverksatt = if (sak is InfotrygdSak.Vedtak) sak.iverksatt else null,
                     tema = sak.tema.name(),
                     behandlingstema = sak.behandlingstema.name(),

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/YtelseDtoMapper.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/YtelseDtoMapper.kt
@@ -21,7 +21,6 @@ object YtelseDtoMapper {
 
     fun toDto(sak: InfotrygdSak) =
             InfotrygdSakDto(
-                    sakId = sak.sakId,
                     iverksatt = sak.iverksatt,
                     tema = sak.tema.name(),
                     behandlingstema = sak.behandlingstema.name(),

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/YtelseDtoMapper.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/YtelseDtoMapper.kt
@@ -21,7 +21,7 @@ object YtelseDtoMapper {
 
     fun toDto(sak: InfotrygdSak) =
             InfotrygdSakDto(
-                    iverksatt = sak.iverksatt,
+                    iverksatt = if (sak is InfotrygdSak.Vedtak) sak.iverksatt else null,
                     tema = sak.tema.name(),
                     behandlingstema = sak.behandlingstema.name(),
                     opphørerFom = if (sak is InfotrygdSak.Vedtak) sak.opphørerFom else null

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/domain/Beregningsgrunnlag.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/domain/Beregningsgrunnlag.kt
@@ -15,7 +15,7 @@ sealed class Beregningsgrunnlag(val identdato: LocalDate,
     }
 
     fun hørerSammenMed(sak: InfotrygdSak) =
-            identdato == sak.iverksatt && behandlingstema.tema == sak.tema
+            sak is InfotrygdSak.Vedtak && identdato == sak.iverksatt && behandlingstema.tema == sak.tema
 
     fun type() = when (this) {
         is Sykepenger -> "Sykepenger"

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/domain/InfotrygdSak.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/domain/InfotrygdSak.kt
@@ -4,14 +4,12 @@ import java.time.LocalDate
 import java.util.*
 
 sealed class InfotrygdSak(val tema: Tema,
-                          val behandlingstema: Behandlingstema,
-                          val iverksatt: LocalDate?) {
+                          val behandlingstema: Behandlingstema) {
 
     class Åpen(tema: Tema,
-               behandlingstema: Behandlingstema,
-               iverksatt: LocalDate?): InfotrygdSak(tema, behandlingstema, iverksatt) {
+               behandlingstema: Behandlingstema): InfotrygdSak(tema, behandlingstema) {
         override fun toString(): String {
-            return "InfotrygdSak.Åpen(tema=$tema, behandlingstema=$behandlingstema, iverksatt=$iverksatt)"
+            return "InfotrygdSak.Åpen(tema=$tema, behandlingstema=$behandlingstema)"
         }
 
         override fun equals(other: Any?): Boolean {
@@ -28,8 +26,8 @@ sealed class InfotrygdSak(val tema: Tema,
 
     class Vedtak(tema: Tema,
                  behandlingstema: Behandlingstema,
-                 iverksatt: LocalDate?,
-                 val opphørerFom: LocalDate?): InfotrygdSak(tema, behandlingstema, iverksatt) {
+                 val iverksatt: LocalDate?,
+                 val opphørerFom: LocalDate?): InfotrygdSak(tema, behandlingstema) {
         override fun toString(): String {
             return "InfotrygdSak.Vedtak(tema=$tema, behandlingstema=$behandlingstema, iverksatt=$iverksatt, opphørerFom=$opphørerFom)"
         }
@@ -41,11 +39,14 @@ sealed class InfotrygdSak(val tema: Tema,
 
             other as InfotrygdSak.Vedtak
 
+            if (iverksatt != other.iverksatt) return false
+
             return opphørerFom == other.opphørerFom
         }
 
         override fun hashCode(): Int {
-            return super.hashCode() * 31 + opphørerFom.hashCode()
+            var hash = 31 * super.hashCode() + Objects.hash(iverksatt)
+            return 31 * hash + Objects.hash(opphørerFom)
         }
     }
 
@@ -57,12 +58,11 @@ sealed class InfotrygdSak(val tema: Tema,
 
         if (tema != other.tema) return false
         if (behandlingstema != other.behandlingstema) return false
-        if (iverksatt != other.iverksatt) return false
 
         return true
     }
 
     override fun hashCode(): Int {
-        return Objects.hash(tema, behandlingstema, iverksatt)
+        return Objects.hash(tema, behandlingstema)
     }
 }

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/domain/InfotrygdSak.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/domain/InfotrygdSak.kt
@@ -1,11 +1,72 @@
 package no.nav.helse.domene.ytelse.domain
 
 import java.time.LocalDate
+import java.util.*
 
-data class InfotrygdSak(
-        val sakId: String?,
-        val iverksatt: LocalDate?,
-        val tema: Tema,
-        val behandlingstema: Behandlingstema,
-        val opphørerFom: LocalDate?
-)
+sealed class InfotrygdSak(val sakId: String?,
+                          val tema: Tema,
+                          val behandlingstema: Behandlingstema,
+                          val iverksatt: LocalDate?) {
+
+    class Åpen(sakId: String?,
+               tema: Tema,
+               behandlingstema: Behandlingstema,
+               iverksatt: LocalDate?): InfotrygdSak(sakId, tema, behandlingstema, iverksatt) {
+        override fun toString(): String {
+            return "InfotrygdSak.Åpen(sakId=$sakId, tema=$tema, behandlingstema=$behandlingstema, iverksatt=$iverksatt)"
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+            if (!super.equals(other)) return false
+            return true
+        }
+
+        override fun hashCode(): Int {
+            return super.hashCode() * 31
+        }
+    }
+
+    class Vedtak(sakId: String?,
+                 tema: Tema,
+                 behandlingstema: Behandlingstema,
+                 iverksatt: LocalDate?,
+                 val opphørerFom: LocalDate?): InfotrygdSak(sakId, tema, behandlingstema, iverksatt) {
+        override fun toString(): String {
+            return "InfotrygdSak.Vedtak(sakId=$sakId, tema=$tema, behandlingstema=$behandlingstema, iverksatt=$iverksatt, opphørerFom=$opphørerFom)"
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+            if (!super.equals(other)) return false
+
+            other as InfotrygdSak.Vedtak
+
+            return opphørerFom == other.opphørerFom
+        }
+
+        override fun hashCode(): Int {
+            return super.hashCode() * 31 + opphørerFom.hashCode()
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as InfotrygdSak
+
+        if (sakId != other.sakId) return false
+        if (tema != other.tema) return false
+        if (behandlingstema != other.behandlingstema) return false
+        if (iverksatt != other.iverksatt) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(sakId, tema, behandlingstema, iverksatt)
+    }
+}

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/domain/InfotrygdSak.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/domain/InfotrygdSak.kt
@@ -3,17 +3,15 @@ package no.nav.helse.domene.ytelse.domain
 import java.time.LocalDate
 import java.util.*
 
-sealed class InfotrygdSak(val sakId: String?,
-                          val tema: Tema,
+sealed class InfotrygdSak(val tema: Tema,
                           val behandlingstema: Behandlingstema,
                           val iverksatt: LocalDate?) {
 
-    class Åpen(sakId: String?,
-               tema: Tema,
+    class Åpen(tema: Tema,
                behandlingstema: Behandlingstema,
-               iverksatt: LocalDate?): InfotrygdSak(sakId, tema, behandlingstema, iverksatt) {
+               iverksatt: LocalDate?): InfotrygdSak(tema, behandlingstema, iverksatt) {
         override fun toString(): String {
-            return "InfotrygdSak.Åpen(sakId=$sakId, tema=$tema, behandlingstema=$behandlingstema, iverksatt=$iverksatt)"
+            return "InfotrygdSak.Åpen(tema=$tema, behandlingstema=$behandlingstema, iverksatt=$iverksatt)"
         }
 
         override fun equals(other: Any?): Boolean {
@@ -28,13 +26,12 @@ sealed class InfotrygdSak(val sakId: String?,
         }
     }
 
-    class Vedtak(sakId: String?,
-                 tema: Tema,
+    class Vedtak(tema: Tema,
                  behandlingstema: Behandlingstema,
                  iverksatt: LocalDate?,
-                 val opphørerFom: LocalDate?): InfotrygdSak(sakId, tema, behandlingstema, iverksatt) {
+                 val opphørerFom: LocalDate?): InfotrygdSak(tema, behandlingstema, iverksatt) {
         override fun toString(): String {
-            return "InfotrygdSak.Vedtak(sakId=$sakId, tema=$tema, behandlingstema=$behandlingstema, iverksatt=$iverksatt, opphørerFom=$opphørerFom)"
+            return "InfotrygdSak.Vedtak(tema=$tema, behandlingstema=$behandlingstema, iverksatt=$iverksatt, opphørerFom=$opphørerFom)"
         }
 
         override fun equals(other: Any?): Boolean {
@@ -58,7 +55,6 @@ sealed class InfotrygdSak(val sakId: String?,
 
         other as InfotrygdSak
 
-        if (sakId != other.sakId) return false
         if (tema != other.tema) return false
         if (behandlingstema != other.behandlingstema) return false
         if (iverksatt != other.iverksatt) return false
@@ -67,6 +63,6 @@ sealed class InfotrygdSak(val sakId: String?,
     }
 
     override fun hashCode(): Int {
-        return Objects.hash(sakId, tema, behandlingstema, iverksatt)
+        return Objects.hash(tema, behandlingstema, iverksatt)
     }
 }

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/dto/InfotrygdSakDto.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/dto/InfotrygdSakDto.kt
@@ -3,6 +3,7 @@ package no.nav.helse.domene.ytelse.dto
 import java.time.LocalDate
 
 data class InfotrygdSakDto(
+        val type: String,
         val iverksatt: LocalDate?,
         val tema: String,
         val behandlingstema: String,

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/dto/InfotrygdSakDto.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/dto/InfotrygdSakDto.kt
@@ -3,7 +3,6 @@ package no.nav.helse.domene.ytelse.dto
 import java.time.LocalDate
 
 data class InfotrygdSakDto(
-        val sakId: String?,
         val iverksatt: LocalDate?,
         val tema: String,
         val behandlingstema: String,

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/infotrygd/InfotrygdSakMapper.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/infotrygd/InfotrygdSakMapper.kt
@@ -11,14 +11,12 @@ object InfotrygdSakMapper {
     fun toSak(sak: no.nav.tjeneste.virksomhet.infotrygdsak.v1.informasjon.InfotrygdSak) =
             when (sak) {
                 is InfotrygdVedtak -> InfotrygdSak.Vedtak(
-                        sakId = sak.sakId,
                         iverksatt = sak.iverksatt?.toLocalDate(),
                         tema = Tema.fraKode(sak.tema.value),
                         behandlingstema = Behandlingstema.fraKode(sak.behandlingstema.value),
                         opphørerFom = sak.opphoerFom?.toLocalDate()
                 )
                 else -> InfotrygdSak.Åpen(
-                        sakId = sak.sakId,
                         iverksatt = sak.iverksatt?.toLocalDate(),
                         tema = Tema.fraKode(sak.tema.value),
                         behandlingstema = Behandlingstema.fraKode(sak.behandlingstema.value)

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/infotrygd/InfotrygdSakMapper.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/infotrygd/InfotrygdSakMapper.kt
@@ -9,11 +9,19 @@ import no.nav.tjeneste.virksomhet.infotrygdsak.v1.informasjon.InfotrygdVedtak
 object InfotrygdSakMapper {
 
     fun toSak(sak: no.nav.tjeneste.virksomhet.infotrygdsak.v1.informasjon.InfotrygdSak) =
-            InfotrygdSak(
-                    sakId = sak.sakId,
-                    iverksatt = sak.iverksatt?.toLocalDate(),
-                    tema = Tema.fraKode(sak.tema.value),
-                    behandlingstema = Behandlingstema.fraKode(sak.behandlingstema.value),
-                    opphørerFom = if (sak is InfotrygdVedtak) sak.opphoerFom?.toLocalDate() else null
-            )
+            when (sak) {
+                is InfotrygdVedtak -> InfotrygdSak.Vedtak(
+                        sakId = sak.sakId,
+                        iverksatt = sak.iverksatt?.toLocalDate(),
+                        tema = Tema.fraKode(sak.tema.value),
+                        behandlingstema = Behandlingstema.fraKode(sak.behandlingstema.value),
+                        opphørerFom = sak.opphoerFom?.toLocalDate()
+                )
+                else -> InfotrygdSak.Åpen(
+                        sakId = sak.sakId,
+                        iverksatt = sak.iverksatt?.toLocalDate(),
+                        tema = Tema.fraKode(sak.tema.value),
+                        behandlingstema = Behandlingstema.fraKode(sak.behandlingstema.value)
+                )
+            }
 }

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/infotrygd/InfotrygdSakMapper.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/infotrygd/InfotrygdSakMapper.kt
@@ -17,7 +17,6 @@ object InfotrygdSakMapper {
                         opphørerFom = sak.opphoerFom?.toLocalDate()
                 )
                 else -> InfotrygdSak.Åpen(
-                        iverksatt = sak.iverksatt?.toLocalDate(),
                         tema = Tema.fraKode(sak.tema.value),
                         behandlingstema = Behandlingstema.fraKode(sak.behandlingstema.value)
                 )

--- a/src/main/kotlin/no/nav/helse/domene/ytelse/infotrygd/InfotrygdService.kt
+++ b/src/main/kotlin/no/nav/helse/domene/ytelse/infotrygd/InfotrygdService.kt
@@ -63,7 +63,7 @@ class InfotrygdService(private val infotrygdBeregningsgrunnlagClient: InfotrygdB
                         sakerMedGrunnlag.filter { infotrygdSakOgGrunnlag ->
                             infotrygdSakOgGrunnlag.grunnlag == null
                         }.forEach { sakUtenGrunnlag ->
-                            log.info("finner ikke grunnlag for sak med sakId=${sakUtenGrunnlag.sak.sakId}")
+                            log.info("finner ikke grunnlag for sak ${sakUtenGrunnlag.sak}")
                         }
 
                         sakerMedGrunnlag

--- a/src/main/kotlin/no/nav/helse/probe/DatakvalitetProbe.kt
+++ b/src/main/kotlin/no/nav/helse/probe/DatakvalitetProbe.kt
@@ -3,13 +3,8 @@ package no.nav.helse.probe
 import io.prometheus.client.Counter
 import io.prometheus.client.Histogram
 import no.nav.helse.common.toLocalDate
-import no.nav.helse.domene.aiy.domain.ArbeidInntektYtelse
-import no.nav.helse.domene.aiy.domain.Arbeidsavtale
-import no.nav.helse.domene.aiy.domain.Arbeidsforhold
-import no.nav.helse.domene.aiy.domain.Permisjon
+import no.nav.helse.domene.aiy.domain.*
 import no.nav.helse.domene.aiy.organisasjon.OrganisasjonService
-import no.nav.helse.domene.aiy.domain.UtbetalingEllerTrekk
-import no.nav.helse.domene.aiy.domain.Virksomhet
 import no.nav.helse.domene.ytelse.domain.*
 import no.nav.tjeneste.virksomhet.infotrygdsak.v1.informasjon.InfotrygdSak
 import no.nav.tjeneste.virksomhet.inntekt.v3.informasjon.inntekt.*
@@ -228,6 +223,8 @@ class DatakvalitetProbe(sensuClient: SensuClient, private val organisasjonServic
         saker.forEach { sakMedGrunnlag ->
             inspiserSak(sakMedGrunnlag.sak)
             sakMedGrunnlag.grunnlag?.let(::inspiserGrunnlag)
+
+            sjekkOmFeltErNull(sakMedGrunnlag, "grunnlag", sakMedGrunnlag.grunnlag)
         }
     }
 
@@ -237,6 +234,11 @@ class DatakvalitetProbe(sensuClient: SensuClient, private val organisasjonServic
         }
         if (sak.tema is Tema.Ukjent) {
             sendDatakvalitetEvent(sak, "tema", Observasjonstype.UkjentTema, "$sak har ukjent tema")
+        }
+
+        if (sak is no.nav.helse.domene.ytelse.domain.InfotrygdSak.Vedtak) {
+            sjekkOmFeltErNull(sak, "iverksatt", sak.iverksatt)
+            sjekkOmFeltErNull(sak, "opphørerFom", sak.opphørerFom)
         }
     }
 

--- a/src/test/kotlin/no/nav/helse/domene/ytelse/YtelseComponentTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/ytelse/YtelseComponentTest.kt
@@ -334,7 +334,6 @@ private val expectedJson = """
   "infotrygd": [
       {
         "sak": {
-          "sakId": "1",
           "tema": "Sykepenger",
           "behandlingstema": "Sykepenger",
           "iverksatt": "2019-05-28"
@@ -350,7 +349,6 @@ private val expectedJson = """
       },
       {
         "sak": {
-          "sakId": "2",
           "tema": "Foreldrepenger",
           "behandlingstema": "ForeldrepengerMedFødsel",
           "iverksatt": "2019-05-14"
@@ -366,7 +364,6 @@ private val expectedJson = """
       },
       {
         "sak": {
-          "sakId": "3",
           "tema": "Foreldrepenger",
           "behandlingstema": "EngangstønadMedFødsel",
           "iverksatt": "2019-05-07"
@@ -382,7 +379,6 @@ private val expectedJson = """
       },
       {
         "sak": {
-          "sakId": "4",
           "tema": "PårørendeSykdom",
           "behandlingstema": "Pleiepenger",
           "iverksatt": "2019-05-01"

--- a/src/test/kotlin/no/nav/helse/domene/ytelse/YtelseComponentTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/ytelse/YtelseComponentTest.kt
@@ -334,6 +334,7 @@ private val expectedJson = """
   "infotrygd": [
       {
         "sak": {
+          "type": "Vedtak",
           "tema": "Sykepenger",
           "behandlingstema": "Sykepenger",
           "iverksatt": "2019-05-28"
@@ -349,6 +350,7 @@ private val expectedJson = """
       },
       {
         "sak": {
+          "type": "Vedtak",
           "tema": "Foreldrepenger",
           "behandlingstema": "ForeldrepengerMedFødsel",
           "iverksatt": "2019-05-14"
@@ -364,6 +366,7 @@ private val expectedJson = """
       },
       {
         "sak": {
+          "type": "Vedtak",
           "tema": "Foreldrepenger",
           "behandlingstema": "EngangstønadMedFødsel",
           "iverksatt": "2019-05-07"
@@ -379,6 +382,7 @@ private val expectedJson = """
       },
       {
         "sak": {
+          "type": "Vedtak",
           "tema": "PårørendeSykdom",
           "behandlingstema": "Pleiepenger",
           "iverksatt": "2019-05-01"

--- a/src/test/kotlin/no/nav/helse/domene/ytelse/YtelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/ytelse/YtelseServiceTest.kt
@@ -79,7 +79,7 @@ class YtelseServiceTest {
     private fun sakerFraInfotrygd(fom: LocalDate, tom: LocalDate, identdatoSykepenger: LocalDate, identdatoForeldrepenger: LocalDate, identdatoEngangstønad: LocalDate, identdatoPleiepenger: LocalDate) =
             listOf(
                     InfotrygdSakOgGrunnlag(
-                            sak = InfotrygdSak(
+                            sak = InfotrygdSak.Vedtak(
                                     sakId = "1",
                                     iverksatt = identdatoSykepenger,
                                     tema = no.nav.helse.domene.ytelse.domain.Tema.Sykepenger,
@@ -95,7 +95,7 @@ class YtelseServiceTest {
                             )
                     ),
                     InfotrygdSakOgGrunnlag(
-                            sak = InfotrygdSak(
+                            sak = InfotrygdSak.Vedtak(
                                     sakId = "2",
                                     iverksatt = identdatoForeldrepenger,
                                     tema = no.nav.helse.domene.ytelse.domain.Tema.Foreldrepenger,
@@ -111,7 +111,7 @@ class YtelseServiceTest {
                             )
                     ),
                     InfotrygdSakOgGrunnlag(
-                            sak = InfotrygdSak(
+                            sak = InfotrygdSak.Vedtak(
                                     sakId = "3",
                                     iverksatt = identdatoEngangstønad,
                                     tema = no.nav.helse.domene.ytelse.domain.Tema.Foreldrepenger,
@@ -127,7 +127,7 @@ class YtelseServiceTest {
                             )
                     ),
                     InfotrygdSakOgGrunnlag(
-                            sak = InfotrygdSak(
+                            sak = InfotrygdSak.Vedtak(
                                     sakId = "4",
                                     iverksatt = identdatoPleiepenger,
                                     tema = no.nav.helse.domene.ytelse.domain.Tema.PårørendeSykdom,

--- a/src/test/kotlin/no/nav/helse/domene/ytelse/YtelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/ytelse/YtelseServiceTest.kt
@@ -80,7 +80,6 @@ class YtelseServiceTest {
             listOf(
                     InfotrygdSakOgGrunnlag(
                             sak = InfotrygdSak.Vedtak(
-                                    sakId = "1",
                                     iverksatt = identdatoSykepenger,
                                     tema = no.nav.helse.domene.ytelse.domain.Tema.Sykepenger,
                                     behandlingstema = no.nav.helse.domene.ytelse.domain.Behandlingstema.Sykepenger,
@@ -96,7 +95,6 @@ class YtelseServiceTest {
                     ),
                     InfotrygdSakOgGrunnlag(
                             sak = InfotrygdSak.Vedtak(
-                                    sakId = "2",
                                     iverksatt = identdatoForeldrepenger,
                                     tema = no.nav.helse.domene.ytelse.domain.Tema.Foreldrepenger,
                                     behandlingstema = no.nav.helse.domene.ytelse.domain.Behandlingstema.ForeldrepengerMedFødsel,
@@ -112,7 +110,6 @@ class YtelseServiceTest {
                     ),
                     InfotrygdSakOgGrunnlag(
                             sak = InfotrygdSak.Vedtak(
-                                    sakId = "3",
                                     iverksatt = identdatoEngangstønad,
                                     tema = no.nav.helse.domene.ytelse.domain.Tema.Foreldrepenger,
                                     behandlingstema = no.nav.helse.domene.ytelse.domain.Behandlingstema.EngangstønadMedFødsel,
@@ -128,7 +125,6 @@ class YtelseServiceTest {
                     ),
                     InfotrygdSakOgGrunnlag(
                             sak = InfotrygdSak.Vedtak(
-                                    sakId = "4",
                                     iverksatt = identdatoPleiepenger,
                                     tema = no.nav.helse.domene.ytelse.domain.Tema.PårørendeSykdom,
                                     behandlingstema = no.nav.helse.domene.ytelse.domain.Behandlingstema.Pleiepenger,

--- a/src/test/kotlin/no/nav/helse/domene/ytelse/domain/BeregningsgrunnlagTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/ytelse/domain/BeregningsgrunnlagTest.kt
@@ -17,7 +17,7 @@ class BeregningsgrunnlagTest {
                 periodeTom = null,
                 behandlingstema = Behandlingstema.SykepengerUtenlandsopphold,
                 vedtak = emptyList()
-        ).hørerSammenMed(InfotrygdSak(
+        ).hørerSammenMed(InfotrygdSak.Vedtak(
                 sakId = "1",
                 iverksatt = identdato,
                 tema = Tema.Sykepenger,
@@ -36,7 +36,7 @@ class BeregningsgrunnlagTest {
                 periodeTom = null,
                 behandlingstema = Behandlingstema.SykepengerUtenlandsopphold,
                 vedtak = emptyList()
-        ).hørerSammenMed(InfotrygdSak(
+        ).hørerSammenMed(InfotrygdSak.Vedtak(
                 sakId = "1",
                 iverksatt = identdato.minusDays(1),
                 tema = Tema.Sykepenger,
@@ -55,7 +55,7 @@ class BeregningsgrunnlagTest {
                 periodeTom = null,
                 behandlingstema = Behandlingstema.SykepengerUtenlandsopphold,
                 vedtak = emptyList()
-        ).hørerSammenMed(InfotrygdSak(
+        ).hørerSammenMed(InfotrygdSak.Vedtak(
                 sakId = "1",
                 iverksatt = identdato,
                 tema = Tema.Foreldrepenger,

--- a/src/test/kotlin/no/nav/helse/domene/ytelse/domain/BeregningsgrunnlagTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/ytelse/domain/BeregningsgrunnlagTest.kt
@@ -18,7 +18,6 @@ class BeregningsgrunnlagTest {
                 behandlingstema = Behandlingstema.SykepengerUtenlandsopphold,
                 vedtak = emptyList()
         ).hørerSammenMed(InfotrygdSak.Vedtak(
-                sakId = "1",
                 iverksatt = identdato,
                 tema = Tema.Sykepenger,
                 behandlingstema = Behandlingstema.SykepengerUtenlandsopphold,
@@ -37,7 +36,6 @@ class BeregningsgrunnlagTest {
                 behandlingstema = Behandlingstema.SykepengerUtenlandsopphold,
                 vedtak = emptyList()
         ).hørerSammenMed(InfotrygdSak.Vedtak(
-                sakId = "1",
                 iverksatt = identdato.minusDays(1),
                 tema = Tema.Sykepenger,
                 behandlingstema = Behandlingstema.SykepengerUtenlandsopphold,
@@ -56,7 +54,6 @@ class BeregningsgrunnlagTest {
                 behandlingstema = Behandlingstema.SykepengerUtenlandsopphold,
                 vedtak = emptyList()
         ).hørerSammenMed(InfotrygdSak.Vedtak(
-                sakId = "1",
                 iverksatt = identdato,
                 tema = Tema.Foreldrepenger,
                 behandlingstema = Behandlingstema.EngangstønadMedFødsel,

--- a/src/test/kotlin/no/nav/helse/domene/ytelse/domain/InfotrygdSakTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/ytelse/domain/InfotrygdSakTest.kt
@@ -75,12 +75,6 @@ class InfotrygdSakTest {
 
         assertNotEquals(sak1, sak3)
         assertNotEquals(sak1.hashCode(), sak3.hashCode())
-
-        val sak4 = enInfotrygdSak()
-                .medIverksatt(LocalDate.now().minusDays(1))
-
-        assertNotEquals(sak1, sak4)
-        assertNotEquals(sak1.hashCode(), sak4.hashCode())
     }
 
     @Test
@@ -94,8 +88,7 @@ class InfotrygdSakTest {
     @Test
     fun `test string-representasjon av infotrygd sak`() {
         val sak = enInfotrygdSak()
-                .medIverksatt(LocalDate.of(2019, 1, 1))
-        assertEquals("InfotrygdSak.Åpen(tema=Sykepenger, behandlingstema=Sykepenger(kode='SP', tema=Sykepenger), iverksatt=2019-01-01)", sak.toString())
+        assertEquals("InfotrygdSak.Åpen(tema=Sykepenger, behandlingstema=Sykepenger(kode='SP', tema=Sykepenger))", sak.toString())
     }
 
     private fun etInfotrygdVedtak() =
@@ -109,8 +102,7 @@ class InfotrygdSakTest {
     private fun enInfotrygdSak() =
             InfotrygdSak.Åpen(
                     tema = Tema.Sykepenger,
-                    behandlingstema = Behandlingstema.Sykepenger,
-                    iverksatt = LocalDate.now()
+                    behandlingstema = Behandlingstema.Sykepenger
             )
 
     private fun InfotrygdSak.Vedtak.medTema(tema: Tema) =
@@ -148,21 +140,12 @@ class InfotrygdSakTest {
     private fun InfotrygdSak.Åpen.medTema(tema: Tema) =
             InfotrygdSak.Åpen(
                     tema = tema,
-                    behandlingstema = behandlingstema,
-                    iverksatt = iverksatt
+                    behandlingstema = behandlingstema
             )
 
     private fun InfotrygdSak.Åpen.medBehandlingstema(behandlingstema: Behandlingstema) =
             InfotrygdSak.Åpen(
                     tema = tema,
-                    behandlingstema = behandlingstema,
-                    iverksatt = iverksatt
-            )
-
-    private fun InfotrygdSak.Åpen.medIverksatt(iverksatt: LocalDate) =
-            InfotrygdSak.Åpen(
-                    tema = tema,
-                    behandlingstema = behandlingstema,
-                    iverksatt = iverksatt
+                    behandlingstema = behandlingstema
             )
 }

--- a/src/test/kotlin/no/nav/helse/domene/ytelse/domain/InfotrygdSakTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/ytelse/domain/InfotrygdSakTest.kt
@@ -1,0 +1,177 @@
+package no.nav.helse.domene.ytelse.domain
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class InfotrygdSakTest {
+    @Test
+    fun `infotrygd vedtak er ulik en infotrygd sak`() {
+        val vedtak = etInfotrygdVedtak()
+        val sak = enInfotrygdSak()
+
+        assertNotEquals(vedtak, sak)
+        assertNotEquals(vedtak.hashCode(), sak.hashCode())
+    }
+
+    @Test
+    fun `infotrygd vedtak er lik en annen med samme verdier`() {
+        val vedtak1 = etInfotrygdVedtak()
+        val vedtak2 = etInfotrygdVedtak()
+
+        assertEquals(vedtak1, vedtak2)
+        assertEquals(vedtak1.hashCode(), vedtak2.hashCode())
+    }
+
+    @Test
+    fun `infotrygd vedtak er ulik en annen med ulike verdier`() {
+        val vedtak1 = etInfotrygdVedtak()
+        val vedtak2 = etInfotrygdVedtak()
+                .medTema(Tema.Foreldrepenger)
+
+        assertNotEquals(vedtak1, vedtak2)
+        assertNotEquals(vedtak1.hashCode(), vedtak2.hashCode())
+
+        val vedtak3 = etInfotrygdVedtak()
+                .medBehandlingstema(Behandlingstema.Foreldrepenger)
+
+        assertNotEquals(vedtak1, vedtak3)
+        assertNotEquals(vedtak1.hashCode(), vedtak3.hashCode())
+
+        val vedtak4 = etInfotrygdVedtak()
+                .medIverksatt(LocalDate.now().minusDays(1))
+
+        assertNotEquals(vedtak1, vedtak4)
+        assertNotEquals(vedtak1.hashCode(), vedtak4.hashCode())
+
+        val vedtak5 = etInfotrygdVedtak()
+                .medOpphørerFom(LocalDate.now().minusDays(1))
+
+        assertNotEquals(vedtak1, vedtak5)
+        assertNotEquals(vedtak1.hashCode(), vedtak5.hashCode())
+    }
+
+    @Test
+    fun `infotrygd sak er lik en annen med samme verdier`() {
+        val sak1 = enInfotrygdSak()
+        val sak2 = enInfotrygdSak()
+
+        assertEquals(sak1, sak2)
+        assertEquals(sak1.hashCode(), sak2.hashCode())
+    }
+
+    @Test
+    fun `infotrygd sak er ulik en annen med ulike verdier`() {
+        val sak1 = enInfotrygdSak()
+        val sak2 = enInfotrygdSak()
+                .medTema(Tema.Foreldrepenger)
+
+        assertNotEquals(sak1, sak2)
+        assertNotEquals(sak1.hashCode(), sak2.hashCode())
+
+        val sak3 = enInfotrygdSak()
+                .medBehandlingstema(Behandlingstema.Foreldrepenger)
+
+        assertNotEquals(sak1, sak3)
+        assertNotEquals(sak1.hashCode(), sak3.hashCode())
+
+        val sak4 = enInfotrygdSak()
+                .medIverksatt(LocalDate.now().minusDays(1))
+
+        assertNotEquals(sak1, sak4)
+        assertNotEquals(sak1.hashCode(), sak4.hashCode())
+    }
+
+    @Test
+    fun `test string-representasjon av infotrygd vedtak`() {
+        val vedtak = etInfotrygdVedtak()
+                .medIverksatt(LocalDate.of(2019, 1, 1))
+                .medOpphørerFom(LocalDate.of(2020, 1, 1))
+        assertEquals("InfotrygdSak.Vedtak(sakId=null, tema=Sykepenger, behandlingstema=Sykepenger(kode='SP', tema=Sykepenger), iverksatt=2019-01-01, opphørerFom=2020-01-01)", vedtak.toString())
+    }
+
+    @Test
+    fun `test string-representasjon av infotrygd sak`() {
+        val sak = enInfotrygdSak()
+                .medIverksatt(LocalDate.of(2019, 1, 1))
+        assertEquals("InfotrygdSak.Åpen(sakId=null, tema=Sykepenger, behandlingstema=Sykepenger(kode='SP', tema=Sykepenger), iverksatt=2019-01-01)", sak.toString())
+    }
+
+    private fun etInfotrygdVedtak() =
+            InfotrygdSak.Vedtak(
+                    sakId = null,
+                    tema = Tema.Sykepenger,
+                    behandlingstema = Behandlingstema.Sykepenger,
+                    iverksatt = LocalDate.now(),
+                    opphørerFom = LocalDate.now().plusMonths(1)
+            )
+
+    private fun enInfotrygdSak() =
+            InfotrygdSak.Åpen(
+                    sakId = null,
+                    tema = Tema.Sykepenger,
+                    behandlingstema = Behandlingstema.Sykepenger,
+                    iverksatt = LocalDate.now()
+            )
+
+    private fun InfotrygdSak.Vedtak.medTema(tema: Tema) =
+            InfotrygdSak.Vedtak(
+                    sakId = sakId,
+                    tema = tema,
+                    behandlingstema = behandlingstema,
+                    iverksatt = iverksatt,
+                    opphørerFom = opphørerFom
+            )
+
+    private fun InfotrygdSak.Vedtak.medBehandlingstema(behandlingstema: Behandlingstema) =
+            InfotrygdSak.Vedtak(
+                    sakId = sakId,
+                    tema = tema,
+                    behandlingstema = behandlingstema,
+                    iverksatt = iverksatt,
+                    opphørerFom = opphørerFom
+            )
+
+    private fun InfotrygdSak.Vedtak.medIverksatt(iverksatt: LocalDate) =
+            InfotrygdSak.Vedtak(
+                    sakId = sakId,
+                    tema = tema,
+                    behandlingstema = behandlingstema,
+                    iverksatt = iverksatt,
+                    opphørerFom = opphørerFom
+            )
+
+    private fun InfotrygdSak.Vedtak.medOpphørerFom(opphørerFom: LocalDate) =
+            InfotrygdSak.Vedtak(
+                    sakId = sakId,
+                    tema = tema,
+                    behandlingstema = behandlingstema,
+                    iverksatt = iverksatt,
+                    opphørerFom = opphørerFom
+            )
+
+    private fun InfotrygdSak.Åpen.medTema(tema: Tema) =
+            InfotrygdSak.Åpen(
+                    sakId = sakId,
+                    tema = tema,
+                    behandlingstema = behandlingstema,
+                    iverksatt = iverksatt
+            )
+
+    private fun InfotrygdSak.Åpen.medBehandlingstema(behandlingstema: Behandlingstema) =
+            InfotrygdSak.Åpen(
+                    sakId = sakId,
+                    tema = tema,
+                    behandlingstema = behandlingstema,
+                    iverksatt = iverksatt
+            )
+
+    private fun InfotrygdSak.Åpen.medIverksatt(iverksatt: LocalDate) =
+            InfotrygdSak.Åpen(
+                    sakId = sakId,
+                    tema = tema,
+                    behandlingstema = behandlingstema,
+                    iverksatt = iverksatt
+            )
+}

--- a/src/test/kotlin/no/nav/helse/domene/ytelse/domain/InfotrygdSakTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/ytelse/domain/InfotrygdSakTest.kt
@@ -88,19 +88,18 @@ class InfotrygdSakTest {
         val vedtak = etInfotrygdVedtak()
                 .medIverksatt(LocalDate.of(2019, 1, 1))
                 .medOpphørerFom(LocalDate.of(2020, 1, 1))
-        assertEquals("InfotrygdSak.Vedtak(sakId=null, tema=Sykepenger, behandlingstema=Sykepenger(kode='SP', tema=Sykepenger), iverksatt=2019-01-01, opphørerFom=2020-01-01)", vedtak.toString())
+        assertEquals("InfotrygdSak.Vedtak(tema=Sykepenger, behandlingstema=Sykepenger(kode='SP', tema=Sykepenger), iverksatt=2019-01-01, opphørerFom=2020-01-01)", vedtak.toString())
     }
 
     @Test
     fun `test string-representasjon av infotrygd sak`() {
         val sak = enInfotrygdSak()
                 .medIverksatt(LocalDate.of(2019, 1, 1))
-        assertEquals("InfotrygdSak.Åpen(sakId=null, tema=Sykepenger, behandlingstema=Sykepenger(kode='SP', tema=Sykepenger), iverksatt=2019-01-01)", sak.toString())
+        assertEquals("InfotrygdSak.Åpen(tema=Sykepenger, behandlingstema=Sykepenger(kode='SP', tema=Sykepenger), iverksatt=2019-01-01)", sak.toString())
     }
 
     private fun etInfotrygdVedtak() =
             InfotrygdSak.Vedtak(
-                    sakId = null,
                     tema = Tema.Sykepenger,
                     behandlingstema = Behandlingstema.Sykepenger,
                     iverksatt = LocalDate.now(),
@@ -109,7 +108,6 @@ class InfotrygdSakTest {
 
     private fun enInfotrygdSak() =
             InfotrygdSak.Åpen(
-                    sakId = null,
                     tema = Tema.Sykepenger,
                     behandlingstema = Behandlingstema.Sykepenger,
                     iverksatt = LocalDate.now()
@@ -117,7 +115,6 @@ class InfotrygdSakTest {
 
     private fun InfotrygdSak.Vedtak.medTema(tema: Tema) =
             InfotrygdSak.Vedtak(
-                    sakId = sakId,
                     tema = tema,
                     behandlingstema = behandlingstema,
                     iverksatt = iverksatt,
@@ -126,7 +123,6 @@ class InfotrygdSakTest {
 
     private fun InfotrygdSak.Vedtak.medBehandlingstema(behandlingstema: Behandlingstema) =
             InfotrygdSak.Vedtak(
-                    sakId = sakId,
                     tema = tema,
                     behandlingstema = behandlingstema,
                     iverksatt = iverksatt,
@@ -135,7 +131,6 @@ class InfotrygdSakTest {
 
     private fun InfotrygdSak.Vedtak.medIverksatt(iverksatt: LocalDate) =
             InfotrygdSak.Vedtak(
-                    sakId = sakId,
                     tema = tema,
                     behandlingstema = behandlingstema,
                     iverksatt = iverksatt,
@@ -144,7 +139,6 @@ class InfotrygdSakTest {
 
     private fun InfotrygdSak.Vedtak.medOpphørerFom(opphørerFom: LocalDate) =
             InfotrygdSak.Vedtak(
-                    sakId = sakId,
                     tema = tema,
                     behandlingstema = behandlingstema,
                     iverksatt = iverksatt,
@@ -153,7 +147,6 @@ class InfotrygdSakTest {
 
     private fun InfotrygdSak.Åpen.medTema(tema: Tema) =
             InfotrygdSak.Åpen(
-                    sakId = sakId,
                     tema = tema,
                     behandlingstema = behandlingstema,
                     iverksatt = iverksatt
@@ -161,7 +154,6 @@ class InfotrygdSakTest {
 
     private fun InfotrygdSak.Åpen.medBehandlingstema(behandlingstema: Behandlingstema) =
             InfotrygdSak.Åpen(
-                    sakId = sakId,
                     tema = tema,
                     behandlingstema = behandlingstema,
                     iverksatt = iverksatt
@@ -169,7 +161,6 @@ class InfotrygdSakTest {
 
     private fun InfotrygdSak.Åpen.medIverksatt(iverksatt: LocalDate) =
             InfotrygdSak.Åpen(
-                    sakId = sakId,
                     tema = tema,
                     behandlingstema = behandlingstema,
                     iverksatt = iverksatt

--- a/src/test/kotlin/no/nav/helse/domene/ytelse/infotrygd/InfotrygdSakMapperTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/ytelse/infotrygd/InfotrygdSakMapperTest.kt
@@ -1,10 +1,10 @@
 package no.nav.helse.domene.ytelse.infotrygd
 
 import no.nav.helse.common.toXmlGregorianCalendar
-import no.nav.helse.domene.ytelse.infotrygd.InfotrygdSakMapper.toSak
 import no.nav.helse.domene.ytelse.domain.Behandlingstema
 import no.nav.helse.domene.ytelse.domain.InfotrygdSak
 import no.nav.helse.domene.ytelse.domain.Tema
+import no.nav.helse.domene.ytelse.infotrygd.InfotrygdSakMapper.toSak
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -28,12 +28,11 @@ class InfotrygdSakMapperTest {
             }
         }
 
-        val expected = InfotrygdSak(
+        val expected = InfotrygdSak.Åpen(
                 sakId = "1",
                 iverksatt = iverksatt,
                 tema = Tema.Sykepenger,
-                behandlingstema = Behandlingstema.SykepengerUtenlandsopphold,
-                opphørerFom = null
+                behandlingstema = Behandlingstema.SykepengerUtenlandsopphold
         )
 
         assertEquals(expected, toSak(given))
@@ -58,7 +57,7 @@ class InfotrygdSakMapperTest {
             this.opphoerFom = opphørerFom.toXmlGregorianCalendar()
         }
 
-        val expected = InfotrygdSak(
+        val expected = InfotrygdSak.Vedtak(
                 sakId = "1",
                 iverksatt = iverksatt,
                 tema = Tema.Sykepenger,

--- a/src/test/kotlin/no/nav/helse/domene/ytelse/infotrygd/InfotrygdSakMapperTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/ytelse/infotrygd/InfotrygdSakMapperTest.kt
@@ -29,7 +29,6 @@ class InfotrygdSakMapperTest {
         }
 
         val expected = InfotrygdSak.Åpen(
-                sakId = "1",
                 iverksatt = iverksatt,
                 tema = Tema.Sykepenger,
                 behandlingstema = Behandlingstema.SykepengerUtenlandsopphold
@@ -58,7 +57,6 @@ class InfotrygdSakMapperTest {
         }
 
         val expected = InfotrygdSak.Vedtak(
-                sakId = "1",
                 iverksatt = iverksatt,
                 tema = Tema.Sykepenger,
                 behandlingstema = Behandlingstema.SykepengerUtenlandsopphold,

--- a/src/test/kotlin/no/nav/helse/domene/ytelse/infotrygd/InfotrygdSakMapperTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/ytelse/infotrygd/InfotrygdSakMapperTest.kt
@@ -29,7 +29,6 @@ class InfotrygdSakMapperTest {
         }
 
         val expected = InfotrygdSak.Åpen(
-                iverksatt = iverksatt,
                 tema = Tema.Sykepenger,
                 behandlingstema = Behandlingstema.SykepengerUtenlandsopphold
         )

--- a/src/test/kotlin/no/nav/helse/domene/ytelse/infotrygd/InfotrygdServiceTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/ytelse/infotrygd/InfotrygdServiceTest.kt
@@ -49,7 +49,7 @@ class InfotrygdServiceTest {
 
         val expected = listOf(
                 InfotrygdSakOgGrunnlag(
-                        sak = InfotrygdSak(
+                        sak = InfotrygdSak.Vedtak(
                                 sakId = "1",
                                 iverksatt = identdatoSykepenger,
                                 tema = Tema.Sykepenger,
@@ -65,7 +65,7 @@ class InfotrygdServiceTest {
                         )
                 ),
                 InfotrygdSakOgGrunnlag(
-                        sak = InfotrygdSak(
+                        sak = InfotrygdSak.Vedtak(
                                 sakId = "2",
                                 iverksatt = identdatoForeldrepenger,
                                 tema = Tema.Foreldrepenger,
@@ -81,7 +81,7 @@ class InfotrygdServiceTest {
                         )
                 ),
                 InfotrygdSakOgGrunnlag(
-                        sak = InfotrygdSak(
+                        sak = InfotrygdSak.Vedtak(
                                 sakId = "3",
                                 iverksatt = identdatoEngangstønad,
                                 tema = Tema.Foreldrepenger,
@@ -97,7 +97,7 @@ class InfotrygdServiceTest {
                         )
                 ),
                 InfotrygdSakOgGrunnlag(
-                        sak = InfotrygdSak(
+                        sak = InfotrygdSak.Vedtak(
                                 sakId = "4",
                                 iverksatt = identdatoPleiepenger,
                                 tema = Tema.PårørendeSykdom,

--- a/src/test/kotlin/no/nav/helse/domene/ytelse/infotrygd/InfotrygdServiceTest.kt
+++ b/src/test/kotlin/no/nav/helse/domene/ytelse/infotrygd/InfotrygdServiceTest.kt
@@ -50,7 +50,6 @@ class InfotrygdServiceTest {
         val expected = listOf(
                 InfotrygdSakOgGrunnlag(
                         sak = InfotrygdSak.Vedtak(
-                                sakId = "1",
                                 iverksatt = identdatoSykepenger,
                                 tema = Tema.Sykepenger,
                                 behandlingstema = Behandlingstema.Sykepenger,
@@ -66,7 +65,6 @@ class InfotrygdServiceTest {
                 ),
                 InfotrygdSakOgGrunnlag(
                         sak = InfotrygdSak.Vedtak(
-                                sakId = "2",
                                 iverksatt = identdatoForeldrepenger,
                                 tema = Tema.Foreldrepenger,
                                 behandlingstema = Behandlingstema.ForeldrepengerMedFødsel,
@@ -82,7 +80,6 @@ class InfotrygdServiceTest {
                 ),
                 InfotrygdSakOgGrunnlag(
                         sak = InfotrygdSak.Vedtak(
-                                sakId = "3",
                                 iverksatt = identdatoEngangstønad,
                                 tema = Tema.Foreldrepenger,
                                 behandlingstema = Behandlingstema.EngangstønadMedFødsel,
@@ -98,7 +95,6 @@ class InfotrygdServiceTest {
                 ),
                 InfotrygdSakOgGrunnlag(
                         sak = InfotrygdSak.Vedtak(
-                                sakId = "4",
                                 iverksatt = identdatoPleiepenger,
                                 tema = Tema.PårørendeSykdom,
                                 behandlingstema = Behandlingstema.Pleiepenger,


### PR DESCRIPTION
Avklaringer med Team Infotrygd har også gitt oss:

```
• hva er forskjellen mellom et InfotrygdVedtak og et InfotrygdSak-objekt?
Vedtak er Foreldrepenger, Sykepenger, Pårørendes sykdom, Engangsstønad og Enslig forsørger.
Sak er rutine Sak for saksbehandling i Infotrygd.
 
• hvorfor mangler sakId veldig ofte på InfotrygdVedtak?
Felt sakId er et nøkkelfelt i Saksrutina.
Det er kun Enslig forsørger som har sakId og dermed knytning til Sak. 
De andre ytelsene i tjenesten har ingen informasjon om sakId.
 
• InfotrygdSak/InfotrygdVedtak mangler ofte `iverksatt`-dato. Hvorfor det?
Det er Engansstønad og Sak som ikke har denne datoen.
I de andre ytelsene er dette et nøkkelfelt.
```

I tillegg kan man anta at `Enslig forsørger` ikke har noe beregningsgrunnlag, siden tjenesten InfotrygdBeregningsgrunnlag ikke gir noen grunnlag med den typen.

`InfotrygdSak` vil aldri ha noen beregningsgrunnlag.